### PR TITLE
GOP-19 Refatora a lógica de gerenciamento de torneios e categorias

### DIFF
--- a/GoPlay_App/Api/Controllers/TournamentManager/Models/TournamentCreateRequest.cs
+++ b/GoPlay_App/Api/Controllers/TournamentManager/Models/TournamentCreateRequest.cs
@@ -60,8 +60,7 @@ public class TournamentCreateRequest
                 tournament.Categories.Add(new CategoryEntity
                 {
                     CategoryType = category.CategoryType,
-                    PlayerLimit = category.PlayerLimit,
-                    IsActive = true,
+                    PlayerLimit = category.PlayerLimit
                 });
             }
         }

--- a/GoPlay_App/Program.cs
+++ b/GoPlay_App/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using GoPlay_App.Api.Controllers.TournamentManager;
+using GoPlay_Core.Validators;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -104,8 +105,10 @@ builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<EmailSender>();
 builder.Services.AddScoped<ITournamentBusiness<TournamentEntity>, TournamentBusiness>();
 builder.Services.AddScoped<ITournamentRepository, TournamentRepository>();
+builder.Services.AddScoped<IValidator<TournamentEntity>, TournamentEntityValidator>();
 builder.Services.AddScoped<ICategoryBusiness<CategoryEntity>, CategoryBusiness>();
 builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
+builder.Services.AddScoped<IValidator<CategoryEntity>, CategoryEntityValidator>();
 
 #endregion
 

--- a/GoPlay_Core/Business/TournamentBusiness.cs
+++ b/GoPlay_Core/Business/TournamentBusiness.cs
@@ -1,4 +1,5 @@
-﻿using GoPlay_App.Api.Controllers.TournamentManager;
+﻿using FluentValidation;
+using GoPlay_App.Api.Controllers.TournamentManager;
 using GoPlay_Core.Entities;
 using GoPlay_Core.Repository.Interfaces;
 
@@ -7,12 +8,21 @@ namespace GoPlay_Core.Business
     public class TournamentBusiness : ITournamentBusiness<TournamentEntity>
     {
         private readonly ITournamentRepository _repository;
-        public TournamentBusiness(ITournamentRepository repository)
+        private readonly IValidator<TournamentEntity> _validator;
+
+        public TournamentBusiness(ITournamentRepository repository, IValidator<TournamentEntity> validator)
         {
             _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+            _validator = validator ?? throw new ArgumentNullException(nameof(validator)); ;
         }
         public async Task Add(TournamentEntity entity, CancellationToken cancellationToken)
         {
+            var validationResult = await _validator.ValidateAsync(entity, cancellationToken);
+            if (!validationResult.IsValid)
+            {
+                throw new ValidationException(validationResult.Errors);
+            }
+
             await _repository.Add(entity);
         }
 

--- a/GoPlay_Core/Entities/CategoryEntity.cs
+++ b/GoPlay_Core/Entities/CategoryEntity.cs
@@ -6,7 +6,6 @@ public class CategoryEntity
     public string CategoryType { get; set; } = string.Empty;
     public int PlayerLimit { get; set; } = 0;
     public int TournamentId { get; set; } = 0;
-    public bool IsActive { get; set; } = true;
 
     public List<UserEntity> Players { get; set; } = new List<UserEntity>();
 

--- a/GoPlay_Core/Entities/UserEntity.cs
+++ b/GoPlay_Core/Entities/UserEntity.cs
@@ -19,7 +19,7 @@ namespace GoPlay_Core.Entities
         public string? TShirtSize { get; set; }
         public bool IsActive { get; set; } = true;
 
-        public IEnumerable<CategoryEntity> Categories { get; set; } = new List<CategoryEntity>();
+        public List<CategoryEntity> Categories { get; set; } = new List<CategoryEntity>();
 
         public UserEntity()
         {

--- a/GoPlay_Core/Validators/CategoryEntityValidator.cs
+++ b/GoPlay_Core/Validators/CategoryEntityValidator.cs
@@ -1,0 +1,23 @@
+﻿using FluentValidation;
+using GoPlay_Core.Entities;
+
+namespace GoPlay_Core.Validators
+{
+    public class CategoryEntityValidator : AbstractValidator<CategoryEntity>
+    {
+        public CategoryEntityValidator()
+        {
+            RuleFor(x => x.CategoryType)
+                .NotEmpty().WithMessage("O tipo da categoria é obrigatório.");
+
+            RuleFor(x => x.PlayerLimit)
+                .GreaterThanOrEqualTo(2).WithMessage("A quantidade mínima de jogadores deve ser 2.")
+                .Must(BePositiveInteger).WithMessage("A quantidade de jogadores deve ser um número inteiro positivo.");
+        }
+
+        private bool BePositiveInteger(int value)
+        {
+            return value > 0;
+        }
+    }
+}

--- a/GoPlay_Core/Validators/TournamentEntityValidator.cs
+++ b/GoPlay_Core/Validators/TournamentEntityValidator.cs
@@ -1,0 +1,57 @@
+﻿using FluentValidation;
+using GoPlay_Core.Entities;
+using GoPlay_Core.Repository.Interfaces;
+
+namespace GoPlay_Core.Validators
+{
+    public class TournamentEntityValidator : AbstractValidator<TournamentEntity>
+    {
+        private readonly ITournamentRepository _tournamentRepository;
+
+        public TournamentEntityValidator(ITournamentRepository tournamentRepository)
+        {
+            _tournamentRepository = tournamentRepository;
+
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("O nome do torneio é obrigatório.")
+                .MustAsync(BeUniqueTournamentNameByDateAndLocation).WithMessage("Já existe um torneio ativo com o mesmo nome, data e local.");
+
+            RuleFor(x => x.GamesStartDate)
+                .NotEmpty().WithMessage("A data de início é obrigatória.")
+                .Must(BeAFutureDate).WithMessage("A data de início deve ser no futuro.");
+
+            RuleFor(x => x.GamesEndDate)
+                .NotEmpty().WithMessage("A data de término é obrigatória.")
+                .GreaterThan(x => x.GamesStartDate).WithMessage("A data de término deve ser posterior à data de início.");
+
+            RuleFor(x => x.Location)
+                .NotEmpty().WithMessage("O local é obrigatório.")
+                .Matches(@"^[\p{L}\p{N}\s.,'-]+$").WithMessage("O local deve conter apenas letras, números e pontuação simples.");
+
+            RuleFor(x => x.RegistrationFee)
+                .GreaterThanOrEqualTo(0).WithMessage("O valor da inscrição deve ser um número positivo ou zero.");
+        }
+
+        private bool BeAFutureDate(DateTime date)
+        {
+            return date > DateTime.UtcNow;
+        }
+
+        private async Task<bool> BeUniqueTournamentNameByDateAndLocation(TournamentEntity tournament, string name, CancellationToken cancellationToken)
+        {
+            var existingTournament = await _tournamentRepository.GetByName(name);
+
+            if (existingTournament == null)
+                return true;
+                        
+            if (existingTournament.IsActive
+                && existingTournament.Location == tournament.Location
+                && existingTournament.GamesStartDate.Date == tournament.GamesStartDate.Date)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/GoPlay_Infra/Migrations/20250428232847_GOP-19-Remove-IsActive-Category.Designer.cs
+++ b/GoPlay_Infra/Migrations/20250428232847_GOP-19-Remove-IsActive-Category.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GoPlay_Infra;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GoPlay_Infra.Migrations
 {
     [DbContext(typeof(GoPlayDbContext))]
-    partial class UserDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250428232847_GOP-19-Remove-IsActive-Category")]
+    partial class GOP19RemoveIsActiveCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GoPlay_Infra/Migrations/20250428232847_GOP-19-Remove-IsActive-Category.cs
+++ b/GoPlay_Infra/Migrations/20250428232847_GOP-19-Remove-IsActive-Category.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GoPlay_Infra.Migrations
+{
+    /// <inheritdoc />
+    public partial class GOP19RemoveIsActiveCategory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Category");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Category",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/GoPlay_Infra/Repository/CategoryRepository.cs
+++ b/GoPlay_Infra/Repository/CategoryRepository.cs
@@ -1,37 +1,130 @@
 ﻿using GoPlay_Core.Entities;
 using GoPlay_Core.Repository.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace GoPlay_Infra.Repository
 {
     public class CategoryRepository : ICategoryRepository
     {
-        public Task Add(CategoryEntity entity)
+        private readonly GoPlayDbContext _context;
+        private readonly ILogger<CategoryRepository> _logger;
+
+        public CategoryRepository(GoPlayDbContext context, ILogger<CategoryRepository> logger)
         {
-            throw new NotImplementedException();
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
-        public Task Update(CategoryEntity entity)
+
+        public async Task Add(CategoryEntity entity)
         {
-            throw new NotImplementedException();
+            try
+            {
+                await _context.Categories.AddAsync(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao adicionar uma nova categoria.");
+                throw new InvalidOperationException("Erro ao adicionar categoria.", ex);
+            }
         }
-        public Task Delete(CategoryEntity entity)
+
+        public async Task Update(CategoryEntity entity)
         {
-            throw new NotImplementedException();
+            try
+            {
+                _context.Categories.Update(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao atualizar a categoria.");
+                throw new InvalidOperationException("Erro ao atualizar categoria.", ex);
+            }
         }
-        public Task<List<CategoryEntity?>> GetAllCategories()
+
+        public async Task Delete(CategoryEntity entity)
         {
-            throw new NotImplementedException();
+            try
+            {
+                _context.Categories.Remove(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao excluir a categoria.");
+                throw new InvalidOperationException("Erro ao excluir categoria.", ex);
+            }
         }
-        public Task<CategoryEntity?> GetById(int id)
+
+        public async Task<List<CategoryEntity?>> GetAllCategories()
         {
-            throw new NotImplementedException();
+            try
+            {
+                var categories = await _context.Categories
+                    .Include(c => c.Players)
+                    .ToListAsync();
+
+                if (categories == null || categories.Count == 0)
+                {
+                    _logger.LogWarning("Nenhuma categoria encontrada.");
+                    return new List<CategoryEntity?>();
+                }
+
+                return categories;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar as categorias.");
+                throw new InvalidOperationException("Erro ao recuperar categorias.", ex);
+            }
         }
-        public Task<CategoryEntity?> GetByCategoryType(string categoryType)
+
+        public async Task<CategoryEntity?> GetById(int id)
         {
-            throw new NotImplementedException();
+            try
+            {
+                return await _context.Categories
+                    .Include(c => c.Players)
+                    .FirstOrDefaultAsync(c => c.Id == id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar a categoria por ID.");
+                throw new InvalidOperationException("Erro ao recuperar categoria por ID.", ex);
+            }
         }
-        public Task<List<CategoryEntity?>> GetByTournamentId(int tournamentId)
+
+        public async Task<CategoryEntity?> GetByCategoryType(string categoryType)
         {
-            throw new NotImplementedException();
+            try
+            {
+                return await _context.Categories
+                    .Include(c => c.Players)
+                    .FirstOrDefaultAsync(c => c.CategoryType.ToLower() == categoryType.ToLower());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar a categoria pelo tipo.");
+                throw new InvalidOperationException("Erro ao recuperar categoria pelo tipo.", ex);
+            }
+        }
+
+        public async Task<List<CategoryEntity?>> GetByTournamentId(int tournamentId)
+        {
+            try
+            {
+                return await _context.Categories
+                    .Include(c => c.Players)
+                    .Where(c => c.TournamentId == tournamentId)
+                    .ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar categorias pelo ID do torneio.");
+                throw new InvalidOperationException("Erro ao recuperar categorias pelo ID do torneio.", ex);
+            }
         }
     }
 }

--- a/GoPlay_Infra/Repository/Mapping/CategoryMap.cs
+++ b/GoPlay_Infra/Repository/Mapping/CategoryMap.cs
@@ -25,10 +25,6 @@ namespace GoPlay_Infra.Repository.Mapping
                 .HasColumnName("TournamentId")
                 .IsRequired();
 
-            builder.Property(c => c.IsActive)
-                .HasColumnName("IsActive")
-                .IsRequired();
-
             builder.HasOne<TournamentEntity>()
                 .WithMany(t => t.Categories)
                 .HasForeignKey(c => c.TournamentId)

--- a/GoPlay_Infra/Repository/TournamentRepository.cs
+++ b/GoPlay_Infra/Repository/TournamentRepository.cs
@@ -1,57 +1,173 @@
 ﻿using GoPlay_Core.Entities;
 using GoPlay_Core.Repository.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace GoPlay_Infra.Repository
 {
     public class TournamentRepository : ITournamentRepository
     {
         private readonly GoPlayDbContext _context;
+        private readonly ILogger<TournamentRepository> _logger;
 
-        public TournamentRepository(GoPlayDbContext context)
+        public TournamentRepository(GoPlayDbContext context, ILogger<TournamentRepository> logger)
         {
-            _context = context;
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task Add(TournamentEntity entity)
         {
-            await _context.Tournaments.AddAsync(entity);
-            await _context.SaveChangesAsync();
+            try
+            {
+                await _context.Tournaments.AddAsync(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao adicionar novo torneio.");
+                throw new InvalidOperationException("Erro ao adicionar torneio.", ex);
+            }
         }
 
         public async Task Update(TournamentEntity entity)
         {
-            throw new NotImplementedException();
+            try
+            {
+                _context.Tournaments.Update(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao atualizar torneio.");
+                throw new InvalidOperationException("Erro ao atualizar torneio.", ex);
+            }
         }
 
         public async Task Delete(TournamentEntity entity)
         {
-            throw new NotImplementedException();
+            try
+            {
+                entity.IsActive = false;
+                _context.Tournaments.Update(entity);
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao desativar torneio.");
+                throw new InvalidOperationException("Erro ao desativar torneio.", ex);
+            }
         }
 
         public async Task<List<TournamentEntity?>> GetAllTournaments()
         {
-            throw new NotImplementedException();
+            try
+            {
+                var tournaments = await _context.Tournaments
+                    .Include(t => t.Categories)
+                    .ToListAsync();
+
+                if (tournaments == null || tournaments.Count == 0)
+                {
+                    _logger.LogWarning("Nenhum torneio encontrado.");
+                    return new List<TournamentEntity?>();
+                }
+
+                return tournaments;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar torneios.");
+                throw new InvalidOperationException("Erro ao recuperar torneios.", ex);
+            }
         }
 
         public async Task<TournamentEntity?> GetById(int id)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var tournament = await _context.Tournaments
+                    .Include(t => t.Categories)
+                    .FirstOrDefaultAsync(t => t.Id == id);
+
+                if (tournament == null)
+                {
+                    _logger.LogWarning("Torneio não encontrado com ID: {Id}", id);
+                    throw new InvalidOperationException($"Torneio não encontrado para o ID {id}.");
+                }
+
+                return tournament;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar torneio por ID.");
+                throw new InvalidOperationException("Erro ao recuperar torneio por ID.", ex);
+            }
         }
 
         public async Task<TournamentEntity?> GetByName(string name)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var tournament = await _context.Tournaments
+                    .Include(t => t.Categories)
+                    .FirstOrDefaultAsync(t => t.Name.ToLower() == name.ToLower());
+
+                return tournament;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar torneio por nome.");
+                throw new InvalidOperationException("Erro ao recuperar torneio por nome.", ex);
+            }
         }
 
         public async Task<List<TournamentEntity?>> GetByLocation(string location)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var tournaments = await _context.Tournaments
+                    .Include(t => t.Categories)
+                    .Where(t => t.Location.ToLower().Contains(location.ToLower()))
+                    .ToListAsync();
+
+                if (tournaments == null || tournaments.Count == 0)
+                {
+                    _logger.LogWarning("Nenhum torneio encontrado para o local: {Location}", location);
+                    return new List<TournamentEntity?>();
+                }
+
+                return tournaments;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar torneios por local.");
+                throw new InvalidOperationException("Erro ao recuperar torneios por local.", ex);
+            }
         }
 
         public async Task<List<TournamentEntity?>> GetByDate(DateTime date)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var tournaments = await _context.Tournaments
+                    .Include(t => t.Categories)
+                    .Where(t => t.GamesStartDate.Date == date.Date)
+                    .ToListAsync();
+
+                if (tournaments == null || tournaments.Count == 0)
+                {
+                    _logger.LogWarning("Nenhum torneio encontrado para a data: {Date}", date.ToShortDateString());
+                    return new List<TournamentEntity?>();
+                }
+
+                return tournaments;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Erro ao recuperar torneios por data.");
+                throw new InvalidOperationException("Erro ao recuperar torneios por data.", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
Refatorar a lógica de gerenciamento de torneios e categorias
•	Atualizado TournamentCreateRequest para garantir o manuseio correto de PlayerLimit.
•	Adicionados TournamentEntityValidator e CategoryEntityValidator para validação.
•	Refatorados TournamentBusiness e CategoryRepository para incluir logging e tratamento de exceções.
•	Removida a propriedade IsActive de CategoryEntity e atualizados os arquivos relacionados.
•	Alterado o tipo de Categories em UserEntity de IEnumerable para List.
•	Atualizado o esquema do banco de dados para refletir as mudanças nos modelos de entidade.